### PR TITLE
test: Fix CORS test cases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -189,17 +189,16 @@
     </dependency>
 
     <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <version>5.9.1</version>
       <scope>test</scope>
-    </dependency>
-
-    <!-- hot swapping, live reload -->
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-devtools</artifactId>
-      <optional>true</optional>
     </dependency>
 
   </dependencies>

--- a/src/test/java/io/zeebe/tasklist/CorsSettingsControllerTest.java
+++ b/src/test/java/io/zeebe/tasklist/CorsSettingsControllerTest.java
@@ -12,7 +12,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.web.server.LocalServerPort;
-import org.springframework.test.context.ActiveProfiles;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 @SpringBootTest(
@@ -22,7 +22,6 @@ import org.springframework.test.web.servlet.MockMvc;
       "logging.level.io.zeebe.tasklist: info",
     })
 @AutoConfigureMockMvc
-@ActiveProfiles("junittest")
 public class CorsSettingsControllerTest {
 
   @LocalServerPort protected int port;
@@ -32,17 +31,20 @@ public class CorsSettingsControllerTest {
   @MockBean protected HazelcastService zeebeHazelcastService;
 
   @Test
+  @WithMockUser(username = "demo", password = "demo")
   public void access_control_origin_request_header_is_checked() throws Exception {
     mockMvc
         .perform(
             options("/")
                 .header("Access-Control-Request-Method", "GET")
                 .header("Host", "localhost")
-                .header("Origin", "http://a.bad-person.internet"))
+                .header("Origin", "http://a.bad-person.internet")
+        )
         .andExpect(status().isForbidden());
   }
 
   @Test
+  @WithMockUser(username = "demo", password = "demo")
   public void access_control_allow_origin_response_header_is_send() throws Exception {
     mockMvc
         .perform(


### PR DESCRIPTION
## Description

Currently, the CORS test cases are failing. The expected response doesn't match because no user was logged in.

Fix the test cases by using `spring-security-test` and log in with the admin user.