### PR TITLE
fix: Add default value for allowedOriginsUrls

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -48,6 +48,7 @@ server:
   port: 8081
   servlet:
     context-path: /
+  allowedOriginsUrls: ""
 
 logging:
   level:


### PR DESCRIPTION
Fixing the application startup failure by adding a default value for 'allowedOriginsUrls'.